### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,4 +38,5 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-openapi-typescript
     secrets: inherit


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/publish.yml` file. The change adds a new `cortexEntityIdOrTag` parameter to the workflow configuration to specify the `service-wl-openapi-typescript` entity for deployment.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R41): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-openapi-typescript` to the `jobs` configuration.