### PR TITLE
FENG-753 - Remove IDP ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @workleap/internal-developer-platform
+


### PR DESCRIPTION
This pull request removes the ownership assignment for the `@workleap/internal-developer-platform` team in the `CODEOWNERS` file.